### PR TITLE
chore: gitignore credentials

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,21 @@
+# Credentials — never commit. Use .env.example as the template.
+.env
+.env.local
+.env.*.local
+.env.*
+!.env.example
+!.env.sample
+
+# Private keys + certs
+*.pem
+*.key
+*.crt
+*.p12
+*.pfx
+
+# Secret directories
+.secrets/
+
+# Workspace auth tokens
+.auth-token
+.auth_token


### PR DESCRIPTION
Standard credential gitignore added: .env / .env.local / .env.*, *.pem/*.key/*.crt/*.p12/*.pfx, .secrets/, .auth-token / .auth_token. Part of org-wide rollout per CEO directive 2026-04-16.



🤖 Generated with [Claude Code](https://claude.com/claude-code)