### PR TITLE
fix: rename new_agent_text_message → new_text_message + a2a.utils → a2a.helpers (a2a-sdk v1)

### DIFF
--- a/adapter.py
+++ b/adapter.py
@@ -193,12 +193,12 @@ class OpenClawA2AExecutor(AgentExecutor):
         self._heartbeat = heartbeat
 
     async def execute(self, context, event_queue):
-        from a2a.utils import new_agent_text_message
+        from a2a.helpers import new_text_message
 
         user_message = extract_message_text(context)
 
         if not user_message:
-            await event_queue.enqueue_event(new_agent_text_message("No message provided"))
+            await event_queue.enqueue_event(new_text_message("No message provided"))
             return
 
         await set_current_task(self._heartbeat, brief_task(user_message))
@@ -237,7 +237,7 @@ class OpenClawA2AExecutor(AgentExecutor):
         finally:
             await set_current_task(self._heartbeat, "")
 
-        await event_queue.enqueue_event(new_agent_text_message(reply))
+        await event_queue.enqueue_event(new_text_message(reply))
 
     async def cancel(self, context, event_queue):  # pragma: no cover
         pass


### PR DESCRIPTION
## Background

`adapter.py`'s lazy import inside `async def execute()` uses two v0 symbols that no longer exist in `a2a-sdk` v1.0.2:

- `from a2a.utils import new_agent_text_message`
  - `a2a.utils` does not exist in v1 (renamed to `a2a.helpers`)
  - `new_agent_text_message` does not exist in v1 (renamed to `new_text_message`)

Verified against the running image (`a2a-sdk==1.0.2`):
```
a2a.utils.new_agent_text_message:    False
a2a.helpers.new_agent_text_message:  False
a2a.utils.new_text_message:          False
a2a.helpers.new_text_message:        True
```

## Why this didn't fail the publish-image smoke gate

The import is **inside `async def execute()`** — module-load doesn't evaluate it. The boot-smoke step in `molecule-ci/.github/workflows/publish-template-image.yml` (added per molecule-core task #126) imports `/app/adapter.py` at module level, so the lazy import slips through. The image ships, then crashes at runtime on the first A2A message with `ImportError: cannot import name 'new_agent_text_message' from 'a2a.utils'`.

This gap is tracked in molecule-core task #131 ("Extend wheel smoke to invoke main() against stub config — would have caught all 6 a2a-sdk migration finds").

## Fix

`s/new_agent_text_message/new_text_message/g` + switch import path `a2a.utils → a2a.helpers`. 1 import + 2 call sites in `adapter.py`.

## Test plan

- [x] `python3 -m py_compile adapter.py` clean
- [ ] Boot-smoke gate (won't catch lazy import — this is a known gap)
- [ ] **Real verification**: provision a workspace using this template, send an A2A message, confirm no ImportError. End-to-end.

## Linked

- Per-template repo trail of identical fixes: `gemini-cli` (PR #10, top-level import → caught by smoke), `crewai`, `openclaw`, `autogen` (lazy imports → slipped through smoke).
- molecule-core memory `reference_a2a_sdk_v0_to_v1_migration` documents this exact migration.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>