### PR TITLE
Skip gateway spawn under MOLECULE_SMOKE_MODE

### DIFF
--- a/adapter.py
+++ b/adapter.py
@@ -56,6 +56,16 @@ class OpenClawAdapter(BaseAdapter):
 
     async def setup(self, config: AdapterConfig) -> None:  # pragma: no cover
         """Install OpenClaw, run onboard, copy workspace files, start gateway."""
+        # Boot-smoke contract (molecule-core#2275): the publish-image gate
+        # invokes us with stub creds + no network so it can exercise lazy
+        # imports inside execute(). Real gateway spawn would fail here
+        # (no valid api_key, no `openclaw` binary on PATH yet), so skip
+        # the heavy setup path entirely. The runtime's smoke_mode short-
+        # circuit fires immediately after create_executor() returns.
+        if os.environ.get("MOLECULE_SMOKE_MODE") == "1":
+            logger.info("MOLECULE_SMOKE_MODE=1 — skipping OpenClaw gateway spawn")
+            return
+
         npm_prefix = os.path.expanduser("~/.local")
         os.environ["PATH"] = f"{npm_prefix}/bin:{os.environ.get('PATH', '')}"
 


### PR DESCRIPTION
## Summary
- The `publish-image` boot-smoke step (added by [molecule-core#2275](https://github.com/Molecule-AI/molecule-core/issues/2275)) invokes the runtime with stub creds and no network so it can exercise lazy imports inside `executor.execute()`.
- Our `setup()` spawns a real `openclaw gateway --dev` subprocess that needs valid creds — under stub env it exits immediately, raising `RuntimeError("OpenClaw gateway process exited")` at adapter.py:170 and failing the workflow.
- This adds a 1-line opt-out at the top of `setup()` so the runtime reaches its smoke short-circuit. Real production boots are unaffected.

## Verification

The smoke gate sets `MOLECULE_SMOKE_MODE=1` along with `MOLECULE_SMOKE_TIMEOUT_SECS=10` and a few stub API keys. With this fix:
- `setup()` returns early, logs the skip
- `create_executor()` returns the `OpenClawA2AExecutor` (which only stores the heartbeat ref, doesn't read any state from setup)
- Runtime's smoke short-circuit invokes `executor.execute()` against a stub `RequestContext` with a 10s timeout

## Test plan
- [ ] CI publish-image workflow passes the boot-smoke step
- [ ] Image still boots normally in real production (env without `MOLECULE_SMOKE_MODE`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)