### PR TITLE
docs(readme): add OpenRouter routing note for anthropic prefixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,5 +20,8 @@ github://Molecule-AI/template-openclaw
 ## Schema version
 `template_schema_version: 1` — compatible with Molecule AI platform v1.x.
 
+## API keys / model routing
+For `anthropic:` or `claude:` model prefixes, set `OPENROUTER_API_KEY` — OpenClaw is OpenAI-compatible only and does not speak the Anthropic API natively, so Claude models are routed through OpenRouter (which exposes them under the OpenAI-compat surface). See `known-issues.md` Issue 5 for the routing table and pre-fix workaround.
+
 ## License
 Business Source License 1.1 — © Molecule AI.


### PR DESCRIPTION
## Summary

Adds a one-paragraph "API keys / model routing" section to the README pointing operators at the right API key + cross-linking the full failure-mode write-up in `known-issues.md` Issue 5:

- For `anthropic:` / `claude:` model prefixes: set `OPENROUTER_API_KEY`
- Reason: openclaw is OpenAI-compat only and doesn't speak Anthropic API natively
- Cross-ref `known-issues.md` Issue 5 (which already documents the routing table + workaround)

Docs-only, +3 / -0 to a single file. No code changes.

## Test plan
- [ ] Render README on GitHub and confirm the new section renders + the cross-ref link is recognisable
- [ ] Sanity-check the `known-issues.md` Issue 5 anchor still exists