### PR TITLE
fix: invoke `openclaw agent --local` to bypass gateway pairing

### DIFF
--- a/adapter.py
+++ b/adapter.py
@@ -294,10 +294,19 @@ class OpenClawA2AExecutor(AgentExecutor):
 
         await set_current_task(self._heartbeat, brief_task(user_message))
 
-        # Call OpenClaw agent via CLI
+        # Call OpenClaw agent via CLI in --local (embedded) mode. The
+        # default path goes through the gateway, which requires a paired
+        # device and explicit scope-upgrade approvals — both interactive
+        # flows that don't fit a headless EC2 workspace. --local bypasses
+        # the gateway entirely and runs the embedded agent against the
+        # configured provider/key, exactly the surface our setup() prepped
+        # via auth-profiles.json + openclaw onboard. Pairing requirement
+        # discovered live during 2026-05-03 4-runtime A2A E2E (`scope
+        # upgrade pending approval` + `pairing required: device is asking
+        # for more scopes than ...`).
         try:
             proc = await asyncio.create_subprocess_exec(
-                "openclaw", "agent",
+                "openclaw", "agent", "--local",
                 "--session-id", context.task_id or "default",
                 "--message", user_message,
                 "--json", "--timeout", "120",

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -142,9 +142,13 @@ async def test_executor_happy_path_extracts_payload_text(monkeypatch):
 
     assert len(queue.events) == 1
     assert "openclaw answered: 42" in repr(queue.events[0])
-    # Subprocess was invoked with the expected fixed flags.
+    # Subprocess was invoked with the expected fixed flags. --local
+    # bypasses the openclaw gateway (which requires interactive device
+    # pairing + scope-upgrade approval) and runs the embedded agent
+    # against the auth-profiles.json setup() prepped.
     args = calls[0]["args"]
-    assert args[0:3] == ("openclaw", "agent", "--session-id")
+    assert args[0:3] == ("openclaw", "agent", "--local")
+    assert "--session-id" in args
     assert "--message" in args
     assert "ping" in args
     assert "--json" in args


### PR DESCRIPTION
## Summary
- Switch the executor from \`openclaw agent ...\` to \`openclaw agent --local ...\` so the embedded agent path runs instead of the gateway path.
- Headless workspaces can't satisfy the gateway's interactive device-pairing + per-scope approval flow; \`--local\` skips both.
- Test updated to assert the \`--local\` flag survives.

## Why
The 2026-05-03 4-runtime A2A E2E surfaced this gateway error on the openclaw workspace:
\`\`\`
OpenClaw error: gateway connect failed: GatewayClientRequestError: scope upgrade pending approval (...)
EMBEDDED FALLBACK: ... GatewayTransportError: gateway closed (1008): pairing required: device is asking for more scopes than ...
\`\`\`

The \`--local\` flag (\`openclaw agent --local\`) runs the embedded agent against the configured provider/key — exactly the surface \`setup()\` already prepped via \`openclaw onboard --auth-choice custom-api-key\` + \`auth-profiles.json\`. No gateway, no pairing, no scope dance.

## Test plan
- [x] \`pytest tests/\` (27 passed)
- [ ] After merge: rerun the 4-runtime A2A E2E, confirm openclaw replies to \`message/send\` instead of the gateway pairing error