### PR TITLE
fix: honor `<PREFIX>_BASE_URL` env var for custom OpenAI-compat shims

### DIFF
--- a/adapter.py
+++ b/adapter.py
@@ -109,8 +109,26 @@ def _resolve_provider_routing(model_str, env, runtime_config=None):
             f"vars in workspace secrets."
         )
 
+    # Provider URL precedence:
+    #   1. <PREFIX>_BASE_URL env var (SDK convention — `OPENAI_BASE_URL`,
+    #      `OPENROUTER_BASE_URL`, etc.) — lets operators point any
+    #      OpenAI-compat prefix at a custom shim (MiniMax, local llama-
+    #      cpp, internal proxy) via the workspace-secrets API.
+    #   2. runtime_config.provider_url from config.yaml (explicit per-
+    #      workspace override).
+    #   3. _PROVIDER_URLS default for the prefix.
+    #
+    # Without (1), the only way to redirect the openai prefix away from
+    # api.openai.com was to edit config.yaml — but the platform doesn't
+    # surface provider_url in the canvas Config tab, so workspace
+    # secrets had no way to influence routing. Caught live during the
+    # 4-runtime A2A E2E (2026-05-03): MiniMax key on the openai prefix
+    # round-tripped to api.openai.com and 401'd.
     default_url = _PROVIDER_URLS.get(prefix, _PROVIDER_URLS["openai"])
-    if runtime_config is not None:
+    env_url = env.get(f"{prefix.upper()}_BASE_URL", "")
+    if env_url:
+        provider_url = env_url
+    elif runtime_config is not None:
         provider_url = runtime_config.get("provider_url", default_url)
     else:
         provider_url = default_url

--- a/tests/test_model_routing.py
+++ b/tests/test_model_routing.py
@@ -225,6 +225,47 @@ def test_runtime_config_provider_url_overrides_default(resolve):
     assert url == "https://my-gateway.internal/v1"
 
 
+def test_env_base_url_overrides_default(resolve):
+    """``OPENAI_BASE_URL`` (SDK-convention env var) routes the openai
+    prefix at a custom OpenAI-compat shim — needed for MiniMax /
+    local-llama / internal-proxy users who only have the workspace
+    secrets API to influence routing (config.yaml's
+    runtime_config.provider_url isn't surfaced in the canvas Config
+    tab). 2026-05-03 4-runtime A2A E2E caught this: MiniMax key on
+    the openai prefix round-tripped to api.openai.com without env
+    honoring."""
+    _, _, url, _ = resolve(
+        "openai:MiniMax-M2.7",
+        env={"OPENAI_API_KEY": "sk-test", "OPENAI_BASE_URL": "https://api.minimax.io/v1"},
+        runtime_config={},
+    )
+    assert url == "https://api.minimax.io/v1"
+
+
+def test_env_base_url_overrides_runtime_config_provider_url(resolve):
+    """Env wins over config.yaml — operators reach for env first
+    (workspace-secrets API surface) and shouldn't have a stale
+    config.yaml override silently shadow it."""
+    _, _, url, _ = resolve(
+        "openai:gpt-4o",
+        env={"OPENAI_API_KEY": "sk-test", "OPENAI_BASE_URL": "https://override.example/v1"},
+        runtime_config={"provider_url": "https://stale-yaml.internal/v1"},
+    )
+    assert url == "https://override.example/v1"
+
+
+def test_env_base_url_per_prefix(resolve):
+    """The env override is per-prefix: `OPENROUTER_BASE_URL` overrides
+    the openrouter default, `GROQ_BASE_URL` the groq default, etc.
+    Pins the generalized `<PREFIX>_BASE_URL` shape."""
+    _, _, url, _ = resolve(
+        "openrouter:anthropic/claude-sonnet-4-5",
+        env={"OPENROUTER_API_KEY": "sk-or", "OPENROUTER_BASE_URL": "https://or-mirror.internal/api/v1"},
+        runtime_config={},
+    )
+    assert url == "https://or-mirror.internal/api/v1"
+
+
 def test_runtime_config_none_uses_default(resolve):
     """Defensive: setup() always passes ``config.runtime_config`` (a
     dict) but the helper accepts ``None`` so unit tests / ad-hoc


### PR DESCRIPTION
## Summary
- \`_resolve_provider_routing\` now checks \`<PREFIX>_BASE_URL\` (SDK convention — \`OPENAI_BASE_URL\`, \`OPENROUTER_BASE_URL\`, etc.) before falling back to \`runtime_config.provider_url\` and the per-prefix default.
- Three new tests pin: env override wins, env beats stale YAML, generalized \`<PREFIX>_BASE_URL\` shape.

## Why
Caught live during the 2026-05-03 4-runtime A2A E2E. Workspace seeded with \`OPENAI_API_KEY\` (MiniMax key) + \`OPENAI_BASE_URL=https://api.minimax.io/v1\`, but the embedded agent still routed to \`api.openai.com\` and 401'd because the helper only consulted \`runtime_config.provider_url\`. The platform doesn't surface \`provider_url\` in the canvas Config tab, so workspace secrets had no way to influence routing.

Precedence order is the SDK-natural one: **env > YAML > prefix-default**. Env wins because operators reach for the workspace-secrets API first; a stale YAML override silently shadowing a fresh env value is a worse failure mode than the inverse.

## Test plan
- [x] \`pytest tests/\` (30 passed, +3)
- [ ] After merge: rerun openclaw A2A probe with \`OPENAI_BASE_URL=https://api.minimax.io/v1\` set, confirm reply lands without the api.openai.com 401