### PR TITLE
feat(adapter): wire molecule a2a_mcp_server into openclaw

### DIFF
--- a/adapter.py
+++ b/adapter.py
@@ -5,8 +5,12 @@ This adapter:
 1. Installs OpenClaw CLI (npm) and missing deps in the container
 2. Runs non-interactive onboard with the configured model provider
 3. Copies workspace files (SOUL.md, BOOTSTRAP.md, etc.) to OpenClaw's workspace dir
-4. Starts the OpenClaw gateway as a background process
-5. Proxies A2A messages via `openclaw agent --json` CLI subprocess
+4. Wires `molecule_runtime.a2a_mcp_server` as a stdio MCP server so the
+   agent can call `list_peers`, `delegate_task`, `commit_memory`, etc.
+   exactly like claude-code can — see ``_build_molecule_mcp_config`` /
+   ``_register_molecule_mcp`` below.
+5. Starts the OpenClaw gateway as a background process
+6. Proxies A2A messages via `openclaw agent --json` CLI subprocess
 """
 
 import asyncio
@@ -15,6 +19,7 @@ import logging
 import os
 import shutil
 import subprocess
+import sys
 
 from molecule_runtime.adapters.base import BaseAdapter, AdapterConfig
 from molecule_runtime.adapters.shared_runtime import brief_task, extract_message_text, set_current_task
@@ -136,6 +141,140 @@ def _resolve_provider_routing(model_str, env, runtime_config=None):
     return prefix, model, provider_url, api_key
 
 
+# --- molecule a2a MCP wire-up --------------------------------------------
+#
+# claude-code gets the platform MCP for free via
+# ``claude_sdk_executor._build_options`` which injects an "a2a" MCP server
+# directly into ClaudeAgentOptions. openclaw runs Node-side and discovers
+# MCP servers from its own ``mcp.servers`` config block — set via
+# ``openclaw mcp set <name> '<json>'`` (cf. ``openclaw mcp --help``).
+#
+# Two concerns to get right:
+#
+# 1. **Env propagation.** openclaw uses the upstream MCP SDK's
+#    ``StdioClientTransport``, which calls ``getDefaultEnvironment()`` and
+#    only forwards an allowlist (HOME, PATH, SHELL, USER, TERM, LOGNAME).
+#    WORKSPACE_ID, PLATFORM_URL, MOLECULE_ORG_ID, CONFIGS_DIR are NOT in
+#    that list. We must pass them explicitly via the ``env:`` field of the
+#    server config — otherwise the MCP server would see WORKSPACE_ID=""
+#    and every /registry/peers call would 400.
+#
+# 2. **Resolution at write-time vs spawn-time.** ``openclaw mcp set``
+#    persists ``command``/``args``/``env`` literally. We resolve the
+#    Python interpreter (``sys.executable``) and a2a_mcp_server.py path
+#    (``get_mcp_server_path()``) at setup-time because both are stable
+#    inside the workspace container — the venv layout doesn't shift
+#    between provision and exec. Env values are resolved at setup-time
+#    too: WORKSPACE_ID and friends are baked into the workspace's
+#    /etc/environment by user-data well before adapter.setup() runs.
+#
+# Idempotent: ``openclaw mcp set`` overwrites entries by name. Re-running
+# setup() (e.g. on container restart) cleanly refreshes the entry.
+_MOLECULE_MCP_NAME = "molecule"
+_MCP_PASSTHROUGH_ENV_VARS = (
+    "WORKSPACE_ID",
+    "PLATFORM_URL",
+    "MOLECULE_ORG_ID",
+    "CONFIGS_DIR",
+    "A2A_MCP_SERVER_PATH",
+)
+
+
+def _build_molecule_mcp_config(env, *, mcp_server_path, python_executable):
+    """Build the JSON config dict for openclaw's ``mcp.servers.molecule``.
+
+    Mirrors claude_sdk_executor's mcp_servers entry — same script, same
+    interpreter, same auth surface — so peer enumeration / delegation /
+    memory tools behave identically across the two runtimes.
+
+    Pure: takes env (a Mapping) and the resolved paths so the test suite
+    can exercise it without subprocess calls or file IO.
+    """
+    payload = {
+        "command": python_executable,
+        "args": [mcp_server_path],
+    }
+    passthrough = {k: env[k] for k in _MCP_PASSTHROUGH_ENV_VARS if env.get(k)}
+    if passthrough:
+        payload["env"] = passthrough
+    return payload
+
+
+def _resolve_mcp_server_path():
+    """Return the on-disk path to ``molecule_runtime/a2a_mcp_server.py``.
+
+    Defers to ``executor_helpers.get_mcp_server_path()`` so this stays in
+    lockstep with claude_sdk_executor's resolution (legacy /app fallback,
+    A2A_MCP_SERVER_PATH override, etc.). Lazy-imported so the module load
+    here doesn't pin a specific molecule_runtime version at import time —
+    a workspace running an older runtime wheel without the helper still
+    boots cleanly, it just skips the MCP wire-up.
+    """
+    try:
+        from molecule_runtime.executor_helpers import get_mcp_server_path
+        return get_mcp_server_path()
+    except Exception:  # pragma: no cover — older runtime wheel
+        return None
+
+
+def _register_molecule_mcp(env=None):
+    """Register the molecule a2a MCP server with openclaw.
+
+    Returns True if the entry was written, False if skipped (missing
+    WORKSPACE_ID, no resolvable a2a_mcp_server, openclaw CLI failure).
+
+    Logs but does not raise: failure to wire MCP is degraded behaviour
+    (the agent runs without peer-discovery tools), not a fatal provision
+    failure. Crashing setup() here would block the workspace from
+    booting at all over what's effectively a feature flag.
+    """
+    env = env if env is not None else os.environ
+    if not env.get("WORKSPACE_ID"):
+        logger.info(
+            "molecule a2a MCP: WORKSPACE_ID not set — skipping MCP wire-up "
+            "(this is expected in dev / smoke runs)"
+        )
+        return False
+
+    mcp_path = _resolve_mcp_server_path()
+    if not mcp_path or not os.path.isfile(mcp_path):
+        logger.warning(
+            "molecule a2a MCP: a2a_mcp_server.py not found "
+            "(resolved=%r) — skipping MCP wire-up",
+            mcp_path,
+        )
+        return False
+
+    payload = _build_molecule_mcp_config(
+        env,
+        mcp_server_path=mcp_path,
+        python_executable=sys.executable,
+    )
+    try:
+        result = subprocess.run(
+            ["openclaw", "mcp", "set", _MOLECULE_MCP_NAME, json.dumps(payload)],
+            capture_output=True, text=True, timeout=30,
+            env={**os.environ, "NODE_NO_WARNINGS": "1"},
+        )
+    except (subprocess.SubprocessError, OSError) as exc:
+        logger.warning("molecule a2a MCP: openclaw mcp set raised %s", exc)
+        return False
+
+    if result.returncode != 0:
+        logger.warning(
+            "molecule a2a MCP: openclaw mcp set failed (rc=%s, stderr=%s)",
+            result.returncode, (result.stderr or "")[:300],
+        )
+        return False
+
+    logger.info(
+        "molecule a2a MCP: registered '%s' → %s %s (env passthrough: %s)",
+        _MOLECULE_MCP_NAME, payload["command"], payload["args"][0],
+        sorted(payload.get("env", {}).keys()),
+    )
+    return True
+
+
 class OpenClawAdapter(BaseAdapter):
 
     def __init__(self):
@@ -253,6 +392,13 @@ class OpenClawAdapter(BaseAdapter):
             with open(auth_file, "w") as f:
                 json_mod.dump(auth_data, f, indent=2)
             logger.info(f"Wrote auth-profiles.json for {provider_name}")
+
+        # 3d. Wire molecule_runtime.a2a_mcp_server into openclaw so the
+        # agent has list_peers / delegate_task / commit_memory / etc. as
+        # MCP tools — same surface claude-code gets via claude_sdk_executor.
+        # Best-effort: failures here log but don't crash setup() (the
+        # workspace can still talk via direct A2A subprocess fallbacks).
+        _register_molecule_mcp(os.environ)
 
         # 4. Copy workspace files from /configs to OpenClaw's workspace dir
         os.makedirs(OPENCLAW_WORKSPACE, exist_ok=True)

--- a/tests/test_molecule_mcp_wireup.py
+++ b/tests/test_molecule_mcp_wireup.py
@@ -1,0 +1,329 @@
+"""Pin the molecule a2a MCP wire-up emitted into ``~/.openclaw/openclaw.json``.
+
+Why this exists
+---------------
+``molecule_runtime`` ships ``a2a_mcp_server.py`` exposing platform A2A
+primitives — ``list_peers``, ``delegate_task``, ``commit_memory``,
+``recall_memory``, etc. — as MCP tools. claude-code gets this for free
+via ``claude_sdk_executor._build_options`` injecting an "a2a" entry
+into ``ClaudeAgentOptions.mcp_servers``. openclaw needs an equivalent
+hand-off because its discovery surface is its own ``mcp.servers``
+config block (cf. ``openclaw mcp --help``).
+
+These tests pin the wire-up's externally-observable shape so a future
+refactor doesn't silently drop:
+
+  - the env-passthrough (WORKSPACE_ID, PLATFORM_URL, MOLECULE_ORG_ID,
+    CONFIGS_DIR, A2A_MCP_SERVER_PATH) — without these the MCP server
+    starts but every /registry/peers call 400s on missing ID,
+  - the ``sys.executable`` interpreter selection (matching claude-
+    code's pattern so the same Python that loaded molecule_runtime
+    also runs the MCP server),
+  - the soft-fail behaviour in ``_register_molecule_mcp`` (missing
+    WORKSPACE_ID, missing a2a_mcp_server.py, openclaw CLI failure all
+    log + return False rather than crash setup() — MCP wire-up
+    failure is degraded behaviour, not a fatal provision failure).
+"""
+
+import json
+import os
+import sys
+import types
+from unittest.mock import MagicMock
+
+import pytest
+
+
+# ---- Stubs ----
+# Match the shape used by tests/test_model_routing.py so adapter.py can
+# import in CI environments without the real molecule_runtime wheel.
+
+
+def _ensure_module(dotted: str) -> types.ModuleType:
+    if dotted not in sys.modules:
+        sys.modules[dotted] = types.ModuleType(dotted)
+    return sys.modules[dotted]
+
+
+def _ensure_attr(mod: types.ModuleType, name: str, value: object) -> None:
+    if not hasattr(mod, name):
+        setattr(mod, name, value)
+
+
+def _install_stubs() -> None:
+    _ensure_module("molecule_runtime")
+    _ensure_module("molecule_runtime.adapters")
+    base = _ensure_module("molecule_runtime.adapters.base")
+    _ensure_attr(base, "BaseAdapter", type("BaseAdapter", (), {}))
+    _ensure_attr(base, "AdapterConfig", type("AdapterConfig", (), {}))
+    shared = _ensure_module("molecule_runtime.adapters.shared_runtime")
+    _ensure_attr(shared, "brief_task", lambda *a, **kw: "")
+    _ensure_attr(shared, "extract_message_text", lambda *a, **kw: "")
+    _ensure_attr(shared, "set_current_task", lambda *a, **kw: None)
+    _ensure_module("a2a")
+    _ensure_module("a2a.server")
+    a2a_exec = _ensure_module("a2a.server.agent_execution")
+    _ensure_attr(a2a_exec, "AgentExecutor", type("AgentExecutor", (), {}))
+
+
+def _load_adapter():
+    _install_stubs()
+    parent_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    if parent_dir not in sys.path:
+        sys.path.insert(0, parent_dir)
+    sys.modules.pop("adapter", None)
+    import adapter  # noqa: WPS433
+    return adapter
+
+
+@pytest.fixture
+def adapter_mod():
+    return _load_adapter()
+
+
+# ---- _build_molecule_mcp_config — pure shape ----
+
+
+def test_build_mcp_config_minimum_shape(adapter_mod):
+    """No env passthrough vars set → just command + args, no env block.
+
+    The MCP server is happy to fall back to its module-level defaults
+    (PLATFORM_URL='http://platform:8080', WORKSPACE_ID='') when env is
+    silent — every call will then 400 in production, but locally /
+    in dev that's still better than refusing to register.
+    """
+    cfg = adapter_mod._build_molecule_mcp_config(
+        env={},
+        mcp_server_path="/path/to/a2a_mcp_server.py",
+        python_executable="/usr/bin/python3",
+    )
+    assert cfg == {
+        "command": "/usr/bin/python3",
+        "args": ["/path/to/a2a_mcp_server.py"],
+    }
+    assert "env" not in cfg
+
+
+def test_build_mcp_config_passes_through_workspace_id(adapter_mod):
+    cfg = adapter_mod._build_molecule_mcp_config(
+        env={"WORKSPACE_ID": "ws-123", "PLATFORM_URL": "http://platform:8080"},
+        mcp_server_path="/x.py",
+        python_executable="/py",
+    )
+    assert cfg["env"] == {
+        "WORKSPACE_ID": "ws-123",
+        "PLATFORM_URL": "http://platform:8080",
+    }
+
+
+def test_build_mcp_config_passes_through_org_id_and_configs_dir(adapter_mod):
+    """SaaS deployments need MOLECULE_ORG_ID for TenantGuard and
+    CONFIGS_DIR for the on-disk auth token. Both flow through."""
+    cfg = adapter_mod._build_molecule_mcp_config(
+        env={
+            "WORKSPACE_ID": "ws-1",
+            "MOLECULE_ORG_ID": "org-uuid",
+            "CONFIGS_DIR": "/configs",
+        },
+        mcp_server_path="/x.py",
+        python_executable="/py",
+    )
+    assert cfg["env"]["MOLECULE_ORG_ID"] == "org-uuid"
+    assert cfg["env"]["CONFIGS_DIR"] == "/configs"
+
+
+def test_build_mcp_config_passes_through_a2a_mcp_server_path_override(adapter_mod):
+    """Templates in non-default layouts can pin the script path via
+    A2A_MCP_SERVER_PATH — the wire-up forwards it so the MCP server
+    inherits the same override on respawn."""
+    cfg = adapter_mod._build_molecule_mcp_config(
+        env={"WORKSPACE_ID": "ws-1", "A2A_MCP_SERVER_PATH": "/custom/mcp.py"},
+        mcp_server_path="/whatever.py",
+        python_executable="/py",
+    )
+    assert cfg["env"]["A2A_MCP_SERVER_PATH"] == "/custom/mcp.py"
+
+
+def test_build_mcp_config_skips_unset_env_vars(adapter_mod):
+    """Empty-string env vars are dropped — the helper never emits
+    ``WORKSPACE_ID=""`` because that would mask the actual missing-
+    config diagnostic the MCP server prints when WORKSPACE_ID is
+    absent."""
+    cfg = adapter_mod._build_molecule_mcp_config(
+        env={"WORKSPACE_ID": "", "PLATFORM_URL": "http://x"},
+        mcp_server_path="/x.py",
+        python_executable="/py",
+    )
+    assert "WORKSPACE_ID" not in cfg.get("env", {})
+    assert cfg["env"]["PLATFORM_URL"] == "http://x"
+
+
+def test_build_mcp_config_does_not_pass_through_unrelated_env(adapter_mod):
+    """Defence-in-depth: the helper only forwards the documented
+    passthrough list. A leaked OPENAI_API_KEY in the openclaw config
+    file would be a real security regression — pin against accidental
+    blanket-forward."""
+    cfg = adapter_mod._build_molecule_mcp_config(
+        env={
+            "WORKSPACE_ID": "ws-1",
+            "OPENAI_API_KEY": "sk-secret",
+            "MINIMAX_API_KEY": "mm-secret",
+            "ANTHROPIC_API_KEY": "ant-secret",
+        },
+        mcp_server_path="/x.py",
+        python_executable="/py",
+    )
+    forwarded = cfg.get("env", {})
+    assert "OPENAI_API_KEY" not in forwarded
+    assert "MINIMAX_API_KEY" not in forwarded
+    assert "ANTHROPIC_API_KEY" not in forwarded
+
+
+# ---- _register_molecule_mcp — soft-fail / happy-path ----
+
+
+def test_register_skips_without_workspace_id(adapter_mod, caplog):
+    """No WORKSPACE_ID → return False, log info, do NOT shell out to
+    openclaw. Dev/smoke runs land here and must not fail loudly."""
+    import logging
+
+    caplog.set_level(logging.INFO)
+    assert adapter_mod._register_molecule_mcp(env={}) is False
+    assert any("WORKSPACE_ID not set" in rec.message for rec in caplog.records)
+
+
+def test_register_skips_when_mcp_server_unresolvable(adapter_mod, monkeypatch, caplog):
+    """No a2a_mcp_server.py on disk (e.g. older runtime wheel without
+    the helper) → return False, log warning, do NOT shell out."""
+    import logging
+
+    monkeypatch.setattr(adapter_mod, "_resolve_mcp_server_path", lambda: None)
+    caplog.set_level(logging.WARNING)
+    assert adapter_mod._register_molecule_mcp(env={"WORKSPACE_ID": "w"}) is False
+    assert any("a2a_mcp_server.py not found" in rec.message for rec in caplog.records)
+
+
+def test_register_happy_path_invokes_openclaw_mcp_set(adapter_mod, monkeypatch, tmp_path):
+    """All preconditions met → call ``openclaw mcp set molecule '<json>'``
+    and return True. The recorded subprocess argv must:
+
+      - end with a parseable JSON blob,
+      - encode the resolved python interpreter (sys.executable),
+      - encode env passthrough for WORKSPACE_ID + PLATFORM_URL.
+    """
+    fake_mcp_path = tmp_path / "a2a_mcp_server.py"
+    fake_mcp_path.write_text("# stub")
+    monkeypatch.setattr(
+        adapter_mod, "_resolve_mcp_server_path", lambda: str(fake_mcp_path)
+    )
+
+    captured = {}
+
+    def fake_run(argv, **kwargs):
+        captured["argv"] = argv
+        captured["kwargs"] = kwargs
+        result = MagicMock()
+        result.returncode = 0
+        result.stderr = ""
+        return result
+
+    monkeypatch.setattr(adapter_mod.subprocess, "run", fake_run)
+
+    env = {
+        "WORKSPACE_ID": "ws-abc",
+        "PLATFORM_URL": "http://platform:8080",
+        "MOLECULE_ORG_ID": "org-1",
+    }
+    assert adapter_mod._register_molecule_mcp(env=env) is True
+
+    argv = captured["argv"]
+    assert argv[0:4] == ["openclaw", "mcp", "set", "molecule"]
+    payload = json.loads(argv[4])
+    assert payload["command"] == sys.executable
+    assert payload["args"] == [str(fake_mcp_path)]
+    assert payload["env"] == {
+        "WORKSPACE_ID": "ws-abc",
+        "PLATFORM_URL": "http://platform:8080",
+        "MOLECULE_ORG_ID": "org-1",
+    }
+
+
+def test_register_returns_false_on_openclaw_nonzero_exit(adapter_mod, monkeypatch, tmp_path, caplog):
+    """openclaw rejected the entry (e.g. schema drift between npm
+    versions) → log warning + return False. setup() continues."""
+    import logging
+
+    fake_mcp_path = tmp_path / "a2a_mcp_server.py"
+    fake_mcp_path.write_text("# stub")
+    monkeypatch.setattr(
+        adapter_mod, "_resolve_mcp_server_path", lambda: str(fake_mcp_path)
+    )
+
+    def fake_run(argv, **kwargs):
+        result = MagicMock()
+        result.returncode = 1
+        result.stderr = "openclaw: unknown subcommand"
+        return result
+
+    monkeypatch.setattr(adapter_mod.subprocess, "run", fake_run)
+
+    caplog.set_level(logging.WARNING)
+    assert adapter_mod._register_molecule_mcp(env={"WORKSPACE_ID": "w"}) is False
+    assert any("openclaw mcp set failed" in rec.message for rec in caplog.records)
+
+
+def test_register_returns_false_when_subprocess_raises(adapter_mod, monkeypatch, tmp_path, caplog):
+    """openclaw binary not on PATH (FileNotFoundError) → soft-fail with
+    a warning. This is the realistic dev path where the npm install
+    step inside setup() either ran in a container we're not exercising
+    here or simply isn't installed."""
+    import logging
+    import subprocess as _subprocess
+
+    fake_mcp_path = tmp_path / "a2a_mcp_server.py"
+    fake_mcp_path.write_text("# stub")
+    monkeypatch.setattr(
+        adapter_mod, "_resolve_mcp_server_path", lambda: str(fake_mcp_path)
+    )
+
+    def fake_run(argv, **kwargs):
+        raise FileNotFoundError("openclaw not on PATH")
+
+    monkeypatch.setattr(adapter_mod.subprocess, "run", fake_run)
+
+    caplog.set_level(logging.WARNING)
+    assert adapter_mod._register_molecule_mcp(env={"WORKSPACE_ID": "w"}) is False
+    assert any("openclaw mcp set raised" in rec.message for rec in caplog.records)
+
+
+def test_register_uses_os_environ_by_default(adapter_mod, monkeypatch):
+    """Calling _register_molecule_mcp() with no env arg falls back to
+    os.environ — the real setup() code path."""
+    fake_mcp_path = "/tmp/nonexistent_mcp.py"
+    # Force the resolver to return the same path the os.path.isfile guard
+    # will reject — so the function returns False without shelling out.
+    monkeypatch.setattr(
+        adapter_mod, "_resolve_mcp_server_path", lambda: fake_mcp_path
+    )
+    monkeypatch.delenv("WORKSPACE_ID", raising=False)
+    # No explicit env kwarg — must default to os.environ which lacks WS_ID.
+    assert adapter_mod._register_molecule_mcp() is False
+
+
+# ---- name / passthrough constants -----------------------------------
+
+
+def test_molecule_mcp_server_name_constant(adapter_mod):
+    """Pin the name 'molecule' so the system prompt + docs (which
+    reference ``mcp__molecule__list_peers`` etc.) stay in sync with
+    the wire-up."""
+    assert adapter_mod._MOLECULE_MCP_NAME == "molecule"
+
+
+def test_passthrough_env_vars_include_required_set(adapter_mod):
+    """Pin the documented passthrough list. Removing one would silently
+    break either workspace identity (WORKSPACE_ID), routing
+    (PLATFORM_URL), SaaS auth (MOLECULE_ORG_ID), or token discovery
+    (CONFIGS_DIR)."""
+    required = {"WORKSPACE_ID", "PLATFORM_URL", "MOLECULE_ORG_ID", "CONFIGS_DIR"}
+    assert required.issubset(set(adapter_mod._MCP_PASSTHROUGH_ENV_VARS))


### PR DESCRIPTION
## Summary

- Wires `molecule_runtime.a2a_mcp_server` into openclaw so the agent gets `list_peers`, `delegate_task`, `delegate_task_async`, `check_task_status`, `commit_memory`, `recall_memory`, `inbox_peek`, `inbox_pop`, `send_message_to_user`, `get_workspace_info` as MCP tools — the same surface claude-code already gets via `claude_sdk_executor._build_options`.
- New helpers `_build_molecule_mcp_config` (pure) + `_register_molecule_mcp` (subprocess wrapper) live in `adapter.py`. `setup()` calls `_register_molecule_mcp(os.environ)` between auth-profiles.json write and gateway start.
- Persists via `openclaw mcp set molecule '<json>'` → `~/.openclaw/openclaw.json` `mcp.servers.molecule`. Idempotent (`set` overwrites by name).
- Soft-fails (logs + continues) on missing `WORKSPACE_ID`, missing `a2a_mcp_server.py`, or `openclaw mcp set` non-zero exit. Wire-up is degraded behaviour, not a fatal provision failure.

Closes #20.

## Why this surface

openclaw spawns MCP servers via the upstream MCP SDK's `StdioClientTransport`. `getDefaultEnvironment()` only forwards an allowlist (`HOME PATH SHELL USER TERM LOGNAME`) — `WORKSPACE_ID`, `PLATFORM_URL`, `MOLECULE_ORG_ID`, `CONFIGS_DIR` are NOT inherited. So we explicitly forward those five env vars (incl. `A2A_MCP_SERVER_PATH` for non-default layouts) via the entry's `env:` field. Without this, the MCP server boots with `WORKSPACE_ID=""` and every `/registry/peers` call 400s.

## Sibling work

- Codex template: Molecule-AI/molecule-ai-workspace-template-codex#15
- Hermes template: tracked as #41

Long-term per the issue, `molecule-ai-workspace-runtime` could expose this as a `ProvidesPlatformMCP` capability so individual templates only declare opt-in.

## Test plan

- [x] `bash -n install.sh` — clean (install.sh untouched in this PR; the wire-up lives in `adapter.py:setup()` because the npm install runs there)
- [x] `python3 -m pytest tests/ -v` — 44 passed (15 existing adapter + 15 routing + 14 new MCP tests)
- [x] Local live test: invoked `openclaw mcp set molecule '<json>'` with the exact payload the helper emits → `openclaw mcp show molecule --json` round-trips identically; entry persists to `~/.openclaw/openclaw.json` under `mcp.servers.molecule`
- [x] Defence-in-depth: test pins that unrelated secrets (`OPENAI_API_KEY`, `MINIMAX_API_KEY`, `ANTHROPIC_API_KEY`) are NOT forwarded into openclaw.json
- [x] All four soft-fail branches covered (missing `WORKSPACE_ID`, unresolvable script, openclaw rc≠0, openclaw raises `FileNotFoundError`)
- [ ] Post-merge: provision a fresh openclaw workspace alongside another runtime on staging, ask the openclaw agent "list your peer workspaces" — should return the peer list (verifies end-to-end on real container env)

🤖 Generated with [Claude Code](https://claude.com/claude-code)