### PR TITLE
fix(executor): reconnect on closed gateway WS — clear cache + active_run_id (#27 c)

### DIFF
--- a/adapter.py
+++ b/adapter.py
@@ -545,6 +545,31 @@ class OpenClawA2AExecutor(AgentExecutor):
         except Exception as exc:  # noqa: BLE001
             return f"OpenClaw gateway connect failed: {exc}"
 
+        # ConnectionError unwinds out of any gw.request() call when the
+        # WS has died mid-session (gateway restart, network blip, host
+        # process crashed). Without resetting `self._gateway`, the cached
+        # closed client persists across execute() calls and every
+        # subsequent dispatch fails identically — workspace wedges
+        # invisibly. Reset so the NEXT call reconnects.
+        # See #27 (c) for the post-merge review that surfaced this.
+        try:
+            return await self._dispatch_inner(gw, user_message)
+        except ConnectionError as exc:
+            logger.warning("openclaw gateway WS dropped (%s) — clearing cache for next reconnect", exc)
+            async with self._gateway_lock:
+                if self._gateway is gw:
+                    self._gateway = None
+            async with self._active_run_lock:
+                self._active_run_id = None
+            return f"OpenClaw gateway disconnected: {exc}. Retry the message — the next call will reconnect."
+
+    async def _dispatch_inner(self, gw, user_message: str) -> str:
+        """Steer / send / wait / history. Extracted so the outer
+        `_dispatch` can wrap a single ConnectionError handler around
+        all gw.request() call sites without duplicating the logic.
+        """
+        from gateway_client import GatewayError
+
         # Push parity: when a run is already in flight for this session,
         # inject the new message via sessions.steer instead of waiting
         # on the prior run to finish. The agent sees both prompts in

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -417,3 +417,111 @@ async def test_cancel_with_active_run_fires_abort():
     _, params = aborts[0]
     assert params["key"] == OpenClawA2AExecutor._SESSION_KEY
     assert params["runId"] == "run-cancel-me"
+
+
+# ---- ConnectionError / WS-dropped recovery (#27 follow-up) ------------
+
+
+@pytest.mark.asyncio
+async def test_executor_resets_gateway_on_connection_error_during_send():
+    """When sessions.send raises ConnectionError (WS died), the
+    executor must:
+      1. Clear `self._gateway` so the next execute() reconnects.
+      2. Clear `self._active_run_id` so the next execute() starts
+         a fresh send (not steer against a dead run).
+      3. Return a recover-friendly error string mentioning retry.
+
+    Without (1), the cached closed client persists — every subsequent
+    execute() returns the cached gateway from `_ensure_gateway()` and
+    fails identically. Workspace wedges invisibly. #27 (c).
+    """
+    fake = _FakeGateway()
+    fake.raise_on["sessions.send"] = ConnectionError("gateway WS closed")
+    executor = OpenClawA2AExecutor(heartbeat=None)
+    executor._gateway = fake
+    executor._active_run_id = None  # no active run; will hit send
+
+    queue = _CapturingQueue()
+    await executor.execute(_ctx("hi"), queue)
+
+    # State reset so next call retries.
+    assert executor._gateway is None, (
+        "gateway cache must clear on ConnectionError so next execute reconnects"
+    )
+    assert executor._active_run_id is None
+    text = _event_text(queue.events[0])
+    assert "OpenClaw gateway disconnected" in text
+    assert "Retry" in text
+
+
+@pytest.mark.asyncio
+async def test_executor_resets_gateway_on_connection_error_during_steer():
+    """Same recovery contract for the steer path. ConnectionError
+    raised during sessions.steer (mid-flight steer call when the
+    WS dies) clears the cache + active_run_id."""
+    fake = _FakeGateway()
+    fake.raise_on["sessions.steer"] = ConnectionError("WS dropped mid-steer")
+    executor = OpenClawA2AExecutor(heartbeat=None)
+    executor._gateway = fake
+    executor._active_run_id = "run-X"  # active → steer path
+
+    queue = _CapturingQueue()
+    await executor.execute(_ctx("steered"), queue)
+
+    assert executor._gateway is None
+    assert executor._active_run_id is None
+    assert "disconnected" in _event_text(queue.events[0])
+
+
+@pytest.mark.asyncio
+async def test_executor_resets_gateway_on_connection_error_during_wait():
+    """ConnectionError during agent.wait (the long-blocking call most
+    likely to hit a server restart) clears the cache + active_run_id."""
+    fake = _FakeGateway()
+    fake.raise_on["agent.wait"] = ConnectionError("server restart mid-wait")
+    executor = OpenClawA2AExecutor(heartbeat=None)
+    executor._gateway = fake
+
+    queue = _CapturingQueue()
+    await executor.execute(_ctx("question"), queue)
+
+    assert executor._gateway is None
+    assert executor._active_run_id is None
+    assert "disconnected" in _event_text(queue.events[0])
+
+
+@pytest.mark.asyncio
+async def test_executor_does_not_clobber_cache_when_replaced_underneath():
+    """Defensive: if a concurrent execute() replaces self._gateway
+    between our request() and our cache-clear, we must NOT clobber the
+    new client. The reset only happens when self._gateway IS the same
+    object that just raised."""
+    old_fake = _FakeGateway()
+    new_fake = _FakeGateway()
+    old_fake.raise_on["sessions.send"] = ConnectionError("old WS dropped")
+
+    executor = OpenClawA2AExecutor(heartbeat=None)
+    executor._gateway = old_fake
+
+    # Simulate the concurrent-replacement race: just before our
+    # cache-clear runs, swap in the new client (as if another coroutine
+    # already detected the disconnect and reconnected).
+    original_request = old_fake.request
+    swap_done = False
+
+    async def swap_then_raise(method, params=None, *, timeout=None):
+        nonlocal swap_done
+        if method == "sessions.send" and not swap_done:
+            executor._gateway = new_fake
+            swap_done = True
+        return await original_request(method, params, timeout=timeout)
+
+    old_fake.request = swap_then_raise
+
+    queue = _CapturingQueue()
+    await executor.execute(_ctx("racy"), queue)
+
+    # The new client must NOT have been clobbered to None.
+    assert executor._gateway is new_fake, (
+        "cache reset must only fire when the dropped client IS the cached one"
+    )


### PR DESCRIPTION
Closes #27 (c). Highest-impact finding from the post-merge 5-axis review of #26.

## What broke

ConnectionError raised by `gw.request()` when the WS died mid-session was uncaught. `self._gateway` stayed set to the closed client → every subsequent `execute()` returned the cached-closed gateway from `_ensure_gateway()` and failed identically. **Workspace wedges invisibly on any gateway restart / network blip.**

## Fix

Wrap the dispatch body in a single `ConnectionError` handler that:
1. Clears `self._gateway` (under `self._gateway_lock`, only when it still IS the dropped client — handles the concurrent-replacement race)
2. Clears `self._active_run_id` so the next `execute()` starts a clean send
3. Returns a recover-friendly error mentioning retry

Extracted the body into `_dispatch_inner` so the handler wraps all `gw.request()` call sites (steer / send / wait / history) without duplicating logic.

## Tests (4 new, mutation-verified)

- ConnectionError during `sessions.send` → cache + run_id cleared
- ConnectionError during `sessions.steer` → cache + run_id cleared
- ConnectionError during `agent.wait` → cache + run_id cleared (the long-blocking call most likely to hit a server restart)
- Concurrent-replacement race: cache reset only fires when the cached client IS the one that raised (defensive against the swap-happens-mid-call window)

Mutation-test: removing the cache-clear under the lock makes the send + steer + wait tests fail with the cached-closed gateway visible in the post-condition. Confirms the cache-clear is what discriminates.

## Out of scope (tracked separately in #27)

- (a) Steer race window — needs lock held through steer call
- (b) Stale `chat.history` returning prior-turn assistant text — needs `since` filter or session.message subscription
- (d) Expanded reconnect tests beyond the 4 in this PR

Each is a real issue but bounded; landing the highest-impact one first while design discussion happens on (b).

🤖 Generated with [Claude Code](https://claude.com/claude-code)